### PR TITLE
Update import path to use module root

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -8,7 +8,7 @@ import (
 	"unicode/utf16"
 	"unsafe"
 	"runtime"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	trc "go_ibm_db/log2"
 	"fmt"
 )
 

--- a/api/api_unix.go
+++ b/api/api_unix.go
@@ -9,7 +9,7 @@
 package api
 
 import (
-    trc "github.com/ibmdb/go_ibm_db/log2"
+    trc "go_ibm_db/log2"
 	"fmt"
 )
 

--- a/api/api_windows.go
+++ b/api/api_windows.go
@@ -6,7 +6,7 @@ package api
 
 import (
 	"syscall"
-    trc "github.com/ibmdb/go_ibm_db/log2"
+    trc "go_ibm_db/log2"
 	"fmt"
 )
 

--- a/api/api_zos.go
+++ b/api/api_zos.go
@@ -12,7 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/ibmruntimes/go-recordio/v2/utils"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	trc "go_ibm_db/log2"
 	"fmt"
 )
 

--- a/api/zapi_unix.go
+++ b/api/zapi_unix.go
@@ -13,7 +13,7 @@ package api
 import (
     "fmt"
 	"unsafe"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	trc "go_ibm_db/log2"
 )
 
 // #cgo aix LDFLAGS: -ldb2

--- a/api/zapi_windows.go
+++ b/api/zapi_windows.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"syscall"
 	"unsafe"
-    trc "github.com/ibmdb/go_ibm_db/log2"
+    trc "go_ibm_db/log2"
 	"fmt"
 )
 

--- a/api/zapi_zos.go
+++ b/api/zapi_zos.go
@@ -12,7 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/ibmruntimes/go-recordio/v2/utils"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	trc "go_ibm_db/log2"
 )
 
 var dll utils.Dll

--- a/column.go
+++ b/column.go
@@ -13,8 +13,8 @@ import (
 	"unsafe"
         "bytes"
 
-	"github.com/ibmdb/go_ibm_db/api"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	"go_ibm_db/api"
+	trc "go_ibm_db/log2"
 )
 
 type BufferLen api.SQLLEN

--- a/conn.go
+++ b/conn.go
@@ -9,8 +9,8 @@ import (
 	"runtime"
 	"unsafe"
 	"fmt"
-	"github.com/ibmdb/go_ibm_db/api"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	"go_ibm_db/api"
+	trc "go_ibm_db/log2"
 )
 
 type Conn struct {

--- a/database.go
+++ b/database.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/ibmdb/go_ibm_db/api"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	"go_ibm_db/api"
+	trc "go_ibm_db/log2"
 )
 
 // CreateDb function will take the db name and user details as parameters

--- a/driver.go
+++ b/driver.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"flag"
 	"os"
-	"github.com/ibmdb/go_ibm_db/api"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	"go_ibm_db/api"
+	trc "go_ibm_db/log2"
 )
 
 var drv Driver

--- a/error.go
+++ b/error.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/ibmdb/go_ibm_db/api"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	"go_ibm_db/api"
+	trc "go_ibm_db/log2"
 )
 
 func IsError(ret api.SQLRETURN) bool {

--- a/handle.go
+++ b/handle.go
@@ -6,8 +6,8 @@ package go_ibm_db
 
 import (
 	"fmt"
-	"github.com/ibmdb/go_ibm_db/api"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	"go_ibm_db/api"
+	trc "go_ibm_db/log2"
 )
 
 func ToHandleAndType(handle interface{}) (h api.SQLHANDLE, ht api.SQLSMALLINT) {

--- a/odbcstmt.go
+++ b/odbcstmt.go
@@ -12,8 +12,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/ibmdb/go_ibm_db/api"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	"go_ibm_db/api"
+	trc "go_ibm_db/log2"
 )
 
 // TODO(brainman): see if I could use SQLExecDirect anywhere

--- a/param.go
+++ b/param.go
@@ -11,8 +11,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/ibmdb/go_ibm_db/api"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	"go_ibm_db/api"
+	trc "go_ibm_db/log2"
 )
 
 type Parameter struct {

--- a/pooling.go
+++ b/pooling.go
@@ -7,7 +7,7 @@ import (
 	"strings"
     "time"
     "sync"
-    trc "github.com/ibmdb/go_ibm_db/log2"
+    trc "go_ibm_db/log2"
 )
 
 //DBP struct type contains the timeout, dbinstance and connection string

--- a/rows.go
+++ b/rows.go
@@ -11,8 +11,8 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/ibmdb/go_ibm_db/api"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	"go_ibm_db/api"
+	trc "go_ibm_db/log2"
 )
 
 type Rows struct {

--- a/sqlOut.go
+++ b/sqlOut.go
@@ -11,8 +11,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/ibmdb/go_ibm_db/api"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	"go_ibm_db/api"
+	trc "go_ibm_db/log2"
 )
 
 // Out struct is used to store the value of a OUT parameter in Stored Procedure

--- a/stats.go
+++ b/stats.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/ibmdb/go_ibm_db/api"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	"go_ibm_db/api"
+	trc "go_ibm_db/log2"
 )
 
 type Stats struct {

--- a/stmt.go
+++ b/stmt.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 	"time"
 	"context"
-	"github.com/ibmdb/go_ibm_db/api"
+	"go_ibm_db/api"
 	"fmt"
-	trc "github.com/ibmdb/go_ibm_db/log2"
+	trc "go_ibm_db/log2"
 )
 
 type Stmt struct {

--- a/tx.go
+++ b/tx.go
@@ -8,7 +8,7 @@ import (
 	"database/sql/driver"
 	"errors"
 
-	"github.com/ibmdb/go_ibm_db/api"
+	"go_ibm_db/api"
 )
 
 type Tx struct {


### PR DESCRIPTION
`go vet` failed due to `log2` and updating import path to use module root will fix the issue. Without this fix there could be unexpected errors. Additionally the usage of `api` import statements have also been improved as they also now use module root as a path. 